### PR TITLE
error running test (vibe-kanban)

### DIFF
--- a/nixos-test-tls.nix
+++ b/nixos-test-tls.nix
@@ -22,7 +22,11 @@ let
       # Building documentation makes the test unnecessarily take a longer time:
       documentation.enable = lib.mkForce false;
 
+      # Containers don't need kernel modules or initrd (they use the host kernel)
       boot.initrd.systemd.enable = false;
+      boot.kernelModules = lib.mkForce [];
+      boot.initrd.kernelModules = lib.mkForce [];
+      boot.initrd.availableKernelModules = lib.mkForce [];
 
       # Essential packages for container functionality
       environment.systemPackages = with pkgs; [

--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -21,7 +21,11 @@ let
       # Building documentation makes the test unnecessarily take a longer time:
       documentation.enable = lib.mkForce false;
 
+      # Containers don't need kernel modules or initrd (they use the host kernel)
       boot.initrd.systemd.enable = false;
+      boot.kernelModules = lib.mkForce [];
+      boot.initrd.kernelModules = lib.mkForce [];
+      boot.initrd.availableKernelModules = lib.mkForce [];
 
       # Essential packages for container functionality
       environment.systemPackages = with pkgs; [


### PR DESCRIPTION
error running test
stage> Running phase: configurePhase
stage> no configure script, doing nothing
stage> Running phase: buildPhase
stage> Running phase: checkPhase
stage> Running phase: installPhase
stage> no Makefile or custom installPhase, doing nothing
stage> Running phase: fixupPhase
stage> shrinking RPATHs of ELF executables and libraries in /nix/store/z449vp5h2kyrs69yc7p1r60hhghkbjgg-stage-2-init.sh
stage> checking for references to /build/ in /nix/store/z449vp5h2kyrs69yc7p1r60hhghkbjgg-stage-2-init.sh...
stage> patching script interpreter paths in /nix/store/z449vp5h2kyrs69yc7p1r60hhghkbjgg-stage-2-init.sh
error: path '/nix/store/3fv6rnw5j52h55wkm2fanr3lbbagv0pb-linux-6.12.48-modules-shrunk/lib' is not in the Nix store
Error: Process completed with exit code 1.
