### PR TITLE
fix: update Keycloak proxy configuration for NixOS 24.05+

### DIFF
--- a/nixos-test.nix
+++ b/nixos-test.nix
@@ -162,7 +162,7 @@ in pkgs.testers.nixosTest {
         http-port = 8080;
         hostname-strict = false;
         hostname-strict-https = false;
-        proxy = "edge";
+        proxy-headers = "xforwarded";
       };
       initialAdminPassword = "admin123";
     };


### PR DESCRIPTION
Replace deprecated `proxy = "edge"` with `proxy-headers = "xforwarded"` to fix NixOS test evaluation error. The proxy option was removed in Keycloak 26.0.0 and replaced with proxy-headers setting.

Fixes the flake check error:
- The option `services.keycloak.settings.proxy' has been removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)